### PR TITLE
Make it release ready

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,26 +23,6 @@ allprojects {
 
     ext {
         release = project.hasProperty('release') && project.getProperty('release')
-
-        pomConfig = {
-            name projectTitle
-            description description
-            url 'http://www.sonarqube.org/'
-            organization {
-                name 'SonarSource'
-                url 'http://www.sonarsource.com'
-            }
-            licenses {
-                license {
-                    name 'GNU LGPL 3'
-                    url 'http://www.gnu.org/licenses/lgpl.txt'
-                    distribution 'repo'
-                }
-            }
-            scm {
-                url 'https://github.com/SonarSource/sonar-go'
-            }
-        }
     }
 
     repositories {
@@ -97,6 +77,50 @@ subprojects {
         }
         excludes(["**/*.txt", "**/*.properties", "**/*.xml", "**/*.xsd", "**/*.html", "**/*.json", "**/*.sql", "**/*.md", "**/*.gradle", "**/*.go", "**/*.out"])
     }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                if (release) {
+                    pom.withXml {
+                        asNode().appendNode('name', projectTitle)
+                        asNode().appendNode('description', description)
+                        asNode().appendNode('url', 'http://www.sonarqube.org/')
+                        
+                        def organization = asNode().appendNode('organization')
+                        organization.appendNode('name', 'SonarSource')
+                        organization.appendNode('url', 'http://www.sonarsource.com')
+
+                        def licenses = asNode().appendNode('licenses')
+                        def license = licenses.appendNode('license')
+                        license.appendNode('name', 'GNU LGPL 3')
+                        license.appendNode('url', 'http://www.gnu.org/licenses/lgpl.txt')
+                        license.appendNode('distribution', 'repo')
+
+                        def scm = asNode().appendNode('scm')
+                        scm.appendNode('url', 'https://github.com/SonarSource/sonar-go')
+
+                        def developers = asNode().appendNode('developers')
+                        def developer = developers.appendNode('developer')
+                        developer.appendNode('id', 'alban-auzeill')
+                        developer.appendNode('name', 'Alban Auzeill')
+
+                        developer = developers.appendNode('developer')
+                        developer.appendNode('id', 'janos-ss')
+                        developer.appendNode('name', 'Janos Gyerik')
+
+                        developer = developers.appendNode('developer')
+                        developer.appendNode('id', 'm-g-sonar')
+                        developer.appendNode('name', 'Michael Gumowski')
+
+                        developer = developers.appendNode('developer')
+                        developer.appendNode('id', 'saberduck')
+                        developer.appendNode('name', 'Tibor Blenessy')
+                    }
+                }
+            }
+        }
+    }
 }
 
 artifactory {
@@ -111,13 +135,13 @@ artifactory {
         }
         defaults {
             properties = [
-                    'build.name': 'sonar-go',
-                    'build.number': (System.getenv('BUILD_ID') ?: System.getenv('BUILD_NUMBER')),
-                    'pr.branch.target': System.getenv('PULL_REQUEST_BRANCH_TARGET'),
-                    'pr.number': System.getenv('PULL_REQUEST_NUMBER'),
-                    'vcs.branch': System.getenv('GIT_BRANCH'),
-                    'vcs.revision': System.getenv('GIT_COMMIT'),
-                    'version': version
+                'build.name': 'sonar-go',
+                'build.number': (System.getenv('BUILD_ID') ?: System.getenv('BUILD_NUMBER')),
+                'pr.branch.target': System.getenv('PULL_REQUEST_BRANCH_TARGET'),
+                'pr.number': System.getenv('PULL_REQUEST_NUMBER'),
+                'vcs.branch': System.getenv('GIT_BRANCH'),
+                'vcs.revision': System.getenv('GIT_COMMIT'),
+                'version': version
             ]
             publications('mavenJava')
             publishPom = true

--- a/common-rule-engine/build.gradle
+++ b/common-rule-engine/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     testCompile project(':uast-generator-java')
 }
 
-
 test {
     useJUnitPlatform()
     testLogging {
@@ -49,8 +48,10 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
-            artifact sourcesJar
-            artifact javadocJar
+            if (release) {
+                artifact sourcesJar
+                artifact javadocJar
+            }
         }
     }
 }

--- a/common-rule-engine/build.gradle
+++ b/common-rule-engine/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java-library'
+    id 'java'
     id 'jacoco'
 }
 
@@ -31,27 +31,5 @@ test {
     testLogging {
         exceptionFormat 'full' // log the full stack trace (default is the 1st line of the stack trace)
         events "skipped", "failed" // verbose log for failed and skipped tests (by default the name of the tests are not logged)
-    }
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-            if (release) {
-                artifact sourcesJar
-                artifact javadocJar
-            }
-        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=org.sonarsource.go
 version=0.1-SNAPSHOT
-description='SonarQube analyzer for Go language'
+description=SonarQube analyzer for Go language
 projectTitle=SonarGo

--- a/sonar-go-plugin/build.gradle
+++ b/sonar-go-plugin/build.gradle
@@ -87,8 +87,10 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             artifact source: shadowJar, classifier: null
-            artifact sourcesJar
-            artifact javadocJar
+            if (release) {
+                artifact sourcesJar
+                artifact javadocJar
+            }
         }
     }
 }

--- a/travis.sh
+++ b/travis.sh
@@ -34,7 +34,7 @@ export INITIAL_VERSION=$(cat gradle.properties | grep version | awk -F= '{print 
 
 if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     echo 'Build and analyze master'
-    ${gradle_cmd} build sonarqube artifactoryPublish \
+    ${gradle_cmd} build sonarqube artifactoryPublish -Prelease=true \
         ${sonar_analysis} \
         -Dsonar.analysis.sha1=$GIT_COMMIT \
         -Dsonar.projectVersion=$INITIAL_VERSION

--- a/uast-generator-java/build.gradle
+++ b/uast-generator-java/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java-library'
+    id 'java'
     id 'jacoco'
 }
 
@@ -40,4 +40,3 @@ test {
         events "skipped", "failed" // verbose log for failed and skipped tests (by default the name of the tests are not logged)
     }
 }
-


### PR DESCRIPTION
This PR fixes potential issue with the POM generated by Gradle.
It also
* add missing information in the generated POM required by Maven Central (developers, 
* remove not needed publication of  common-rule-engine
* generate source jar and javadoc jars (required by Maven Central) only for releases (on master branch)