### PR TITLE
Support GOPATH with multiple entries when importing the coverage (Fix #308)

### DIFF
--- a/its/plugin/tests/src/test/java/com/sonar/it/go/Tests.java
+++ b/its/plugin/tests/src/test/java/com/sonar/it/go/Tests.java
@@ -55,7 +55,7 @@ public class Tests {
   public static final Orchestrator ORCHESTRATOR;
 
   static {
-    String defaultRuntimeVersion = "true".equals(System.getenv("SONARSOURCE_QA")) ? null : "7.2.0.12501"; // TODO LATEST_RELEASE[7.2]
+    String defaultRuntimeVersion = "true".equals(System.getenv("SONARSOURCE_QA")) ? null : "7.2.0.12767"; // TODO LATEST_RELEASE[7.2]
     OrchestratorBuilder builder = Orchestrator.builderEnv()
       .setSonarVersion(System.getProperty("sonar.runtimeVersion", defaultRuntimeVersion))
       .restoreProfileAtStartup(FileLocation.ofClasspath(RESOURCE_DIRECTORY + "/empty-profile.xml"));

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoCoverageReport.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoCoverageReport.java
@@ -91,6 +91,13 @@ public final class GoCoverageReport {
     }
   }
 
+  /**
+   *  It is possible that absolutePath references a file that does not exist in the file system.
+   *  It happens when go tests where executed on a different computer.
+   *  Even when absolute path does not match a file of the project, this method try to find a valid
+   *  mach using a shorter relative path.
+   *  @see <a href="https://github.com/SonarSource/sonar-go/issues/218">sonar-go/issues/218</a>
+   */
   private static InputFile findInputFile(String absolutePath, FileSystem fileSystem) {
     FilePredicates predicates = fileSystem.predicates();
     InputFile inputFile = fileSystem.inputFile(predicates.hasAbsolutePath(absolutePath));

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoCoverageReport.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoCoverageReport.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.go.plugin;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,7 +60,7 @@ public final class GoCoverageReport {
   private GoCoverageReport() {
   }
 
-  public static void saveCoverageReports(SensorContext sensorContext, GoContext goContext) throws IOException {
+  public static void saveCoverageReports(SensorContext sensorContext, GoPathContext goContext) throws IOException {
     Coverage coverage = new Coverage(goContext);
     for (Path reportPath : getReportPaths(sensorContext)) {
       parse(reportPath, coverage);
@@ -154,16 +153,16 @@ public final class GoCoverageReport {
   }
 
   static class Coverage {
-    final GoContext goContext;
+    final GoPathContext goContext;
     Map<String, List<CoverageStat>> fileMap = new HashMap<>();
 
-    Coverage(GoContext goContext) {
+    Coverage(GoPathContext goContext) {
       this.goContext = goContext;
     }
 
     void add(CoverageStat coverage) {
       fileMap
-        .computeIfAbsent(coverage.resolvePath(goContext), key -> new ArrayList<>())
+        .computeIfAbsent(goContext.resolveUsingGoPath(coverage.filePath), key -> new ArrayList<>())
         .add(coverage);
     }
   }
@@ -236,10 +235,6 @@ public final class GoCoverageReport {
 
   static class CoverageStat {
 
-    static final String LINUX_ABSOLUTE_PREFIX = "_/";
-    static final String WINDOWS_ABSOLUTE_PREFIX = "_\\";
-    static final Pattern WINDOWS_ABSOLUTE_REGEX = Pattern.compile("^_\\\\(\\w)_\\\\");
-
     final String filePath;
     final int startLine;
     final int startCol;
@@ -262,39 +257,6 @@ public final class GoCoverageReport {
       count = Integer.parseInt(matcher.group(7));
     }
 
-    String resolvePath(GoContext context) {
-      if (filePath.startsWith(LINUX_ABSOLUTE_PREFIX)) {
-        return filePath.substring(1);
-      } else if (filePath.startsWith(WINDOWS_ABSOLUTE_PREFIX)) {
-        Matcher matcher = WINDOWS_ABSOLUTE_REGEX.matcher(filePath);
-        if (matcher.find()) {
-          matcher.reset();
-          return matcher.replaceFirst("$1:\\\\");
-        }
-      } else if (context.goPath != null && !context.goPath.isEmpty()) {
-        return context.goPath + context.fileSeparator + filePath;
-      }
-      return filePath;
-    }
   }
 
-  static class GoContext {
-    static final GoContext DEFAULT = new GoContext(File.separatorChar, defaultGoSrcPath());
-    final char fileSeparator;
-    final String goPath;
-
-    GoContext(char fileSeparator, @Nullable String goPath) {
-      this.fileSeparator = fileSeparator;
-      this.goPath = goPath;
-    }
-
-    @Nullable
-    static String defaultGoSrcPath() {
-      String path = System.getenv("GOPATH");
-      if (path != null && !path.isEmpty()) {
-        return path + File.separatorChar + "src";
-      }
-      return null;
-    }
-  }
 }

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoCoverageReport.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoCoverageReport.java
@@ -162,7 +162,7 @@ public final class GoCoverageReport {
 
     void add(CoverageStat coverage) {
       fileMap
-        .computeIfAbsent(goContext.resolveUsingGoPath(coverage.filePath), key -> new ArrayList<>())
+        .computeIfAbsent(goContext.resolve(coverage.filePath), key -> new ArrayList<>())
         .add(coverage);
     }
   }

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoPathContext.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoPathContext.java
@@ -66,7 +66,14 @@ class GoPathContext {
     return parentPath + fileSeparator + childPath;
   }
 
-  String resolveUsingGoPath(String filePath) {
+  /**
+   * Try to resolve the absolute path of the given filePath. If filePath is relative,
+   * try to append the first GOPATH entry where this file exists, otherwise return
+   * a non-existing absolute path using the first GOPATH entry (or just filePath itself
+   * if GOPATH is empty).
+   * See GoCoverageReport#findInputFile to understand why a non-existing file is useful.
+   */
+  String resolve(String filePath) {
     return resolvedPaths.computeIfAbsent(filePath, path -> {
       if (path.startsWith(LINUX_ABSOLUTE_PREFIX)) {
         return path.substring(1);

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoPathContext.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoPathContext.java
@@ -30,6 +30,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.sonar.api.batch.fs.FileSystem;
 
 class GoPathContext {
   private static final String LINUX_ABSOLUTE_PREFIX = "_/";
@@ -67,11 +68,12 @@ class GoPathContext {
   }
 
   /**
-   * Try to resolve the absolute path of the given filePath. If filePath is relative,
+   * Try to resolve the absolute path of the given filePath. If filePath is absolute
+   * (start with _) return the absolute path without the '_'. If filePath is relative,
    * try to append the first GOPATH entry where this file exists, otherwise return
    * a non-existing absolute path using the first GOPATH entry (or just filePath itself
    * if GOPATH is empty).
-   * See GoCoverageReport#findInputFile to understand why a non-existing file is useful.
+   * See {@link GoCoverageReport#findInputFile(String, FileSystem)}
    */
   String resolve(String filePath) {
     return resolvedPaths.computeIfAbsent(filePath, path -> {

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoPathContext.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoPathContext.java
@@ -1,0 +1,99 @@
+/*
+ * SonarQube Go Plugin
+ * Copyright (C) 2018-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.go.plugin;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+class GoPathContext {
+  private static final String LINUX_ABSOLUTE_PREFIX = "_/";
+  private static final String WINDOWS_ABSOLUTE_PREFIX = "_\\";
+  private static final Pattern WINDOWS_ABSOLUTE_REGEX = Pattern.compile("^_\\\\(\\w)_\\\\");
+  private static final int MAX_PATH_CACHE_SIZE = 100;
+
+  static final GoPathContext DEFAULT = new GoPathContext(File.separatorChar, File.pathSeparator, System.getenv("GOPATH"));
+  final char fileSeparator;
+  final List<String> goSrcPathList;
+  final Map<String, String> resolvedPaths = new LinkedHashMap<String, String>() {
+    @Override
+    protected boolean removeEldestEntry(Map.Entry eldest) {
+      return size() > MAX_PATH_CACHE_SIZE;
+    }
+  };
+
+  GoPathContext(char fileSeparator, String pathSeparator, @Nullable String goPath) {
+    this.fileSeparator = fileSeparator;
+    List<String> goPathEntries = Collections.emptyList();
+    if (goPath != null) {
+      goPathEntries = Arrays.asList(goPath.split(pathSeparator));
+    }
+    this.goSrcPathList = goPathEntries.stream()
+      .filter(path -> !path.isEmpty())
+      .map(path -> concat(path, "src"))
+      .collect(Collectors.toList());
+  }
+
+  String concat(String parentPath, String childPath) {
+    if (parentPath.isEmpty() || parentPath.charAt(parentPath.length() - 1) == fileSeparator) {
+      return parentPath + childPath;
+    }
+    return parentPath + fileSeparator + childPath;
+  }
+
+  String resolveUsingGoPath(String filePath) {
+    return resolvedPaths.computeIfAbsent(filePath, path -> {
+      if (path.startsWith(LINUX_ABSOLUTE_PREFIX)) {
+        return path.substring(1);
+      } else if (path.startsWith(WINDOWS_ABSOLUTE_PREFIX)) {
+        Matcher matcher = WINDOWS_ABSOLUTE_REGEX.matcher(path);
+        if (matcher.find()) {
+          matcher.reset();
+          return matcher.replaceFirst("$1:\\\\");
+        }
+      }
+      return prefixByFirstValidGoPath(path)
+        .orElseGet(() -> prefixByFirstGoPath(path));
+    });
+  }
+
+  private Optional<String> prefixByFirstValidGoPath(String filePath) {
+    return goSrcPathList.stream()
+      .map(goPath -> concat(goPath, filePath))
+      .filter(path -> new File(path).exists())
+      .findFirst();
+  }
+
+  private String prefixByFirstGoPath(String filePath) {
+    if (goSrcPathList.isEmpty()) {
+      return filePath;
+    }
+    return concat(goSrcPathList.get(0), filePath);
+  }
+
+}

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoSensor.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoSensor.java
@@ -98,7 +98,7 @@ public class GoSensor implements Sensor {
       }
     }
     try {
-      saveCoverageReports(context, GoCoverageReport.GoContext.DEFAULT);
+      saveCoverageReports(context, GoPathContext.DEFAULT);
     } catch (Exception e) {
       LOG.error("Coverage import failed: {}", e.getMessage(), e);
     }

--- a/sonar-go-plugin/src/test/java/org/sonar/go/plugin/GoPathContextTest.java
+++ b/sonar-go-plugin/src/test/java/org/sonar/go/plugin/GoPathContextTest.java
@@ -24,91 +24,135 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GoPathContextTest {
 
-  @Test
-  void concat() {
-    GoPathContext linuxContext = new GoPathContext('/', ":", "/home/paul/go");
-    GoPathContext windowsContext = new GoPathContext('\\', ";", "C:\\Users\\paul\\go");
+  static String[] tmpDirWithFile = new String[2];
+  static String[] existingFileAbsolutePath = new String[2];
+  static String tmpDirWithoutFile;
+  static String invalidTmpDir;
 
-    assertThat(linuxContext.concat("/home", "paul")).isEqualTo("/home/paul");
-    assertThat(linuxContext.concat("/home/", "paul")).isEqualTo("/home/paul");
-    assertThat(linuxContext.concat("/", "paul")).isEqualTo("/paul");
-    assertThat(linuxContext.concat("", "paul")).isEqualTo("paul");
+  @BeforeAll
+  static void prepare_temporary_folder() throws IOException {
+    String[] suffixes = {"0", "1"};
+    for (int i = 0; i < suffixes.length; i++) {
+      String suffix = suffixes[i];
+      Path dirWithFile = Files.createTempDirectory("tmp_dir_with_file_" + suffix);
+      dirWithFile.toFile().deleteOnExit();
+      Path srcDir = dirWithFile.resolve("src");
+      Files.createDirectory(srcDir);
+      Path existingFile = srcDir.resolve("file.go");
+      Files.createFile(existingFile);
+      tmpDirWithFile[i] = dirWithFile.toAbsolutePath().toString();
+      existingFileAbsolutePath[i] = existingFile.toAbsolutePath().toString();
+    }
 
-    assertThat(windowsContext.concat("C:\\Users", "paul")).isEqualTo("C:\\Users\\paul");
-    assertThat(windowsContext.concat("C:\\Users\\", "paul")).isEqualTo("C:\\Users\\paul");
-    assertThat(windowsContext.concat("C:\\", "paul")).isEqualTo("C:\\paul");
-    assertThat(windowsContext.concat("", "paul")).isEqualTo("paul");
+    Path dirWithoutFile = Files.createTempDirectory("tmp_dir_without_file");
+    dirWithoutFile.toFile().deleteOnExit();
+    Files.createDirectory(dirWithoutFile.resolve("src"));
+
+    tmpDirWithoutFile = dirWithoutFile.toAbsolutePath().toString();
+    invalidTmpDir = Paths.get("directory", "not", "found").toString();
   }
 
   @Test
-  void source_directories() {
-    GoPathContext linuxContext = new GoPathContext('/', ":", "/home/paul/go:/home/luc/go");
-    assertThat(linuxContext.goSrcPathList).containsExactly("/home/paul/go/src", "/home/luc/go/src");
-
-    GoPathContext windowsContext = new GoPathContext('\\', ";", "C:\\Users\\paul\\go;C:\\Users\\luc\\go");
-    assertThat(windowsContext.goSrcPathList).containsExactly("C:\\Users\\paul\\go\\src", "C:\\Users\\luc\\go\\src");
+  void concat_linux() {
+    GoPathContext context = new GoPathContext('/', ":", "/home/paul/go");
+    assertThat(context.concat("/home", "paul")).isEqualTo("/home/paul");
+    assertThat(context.concat("/home/", "paul")).isEqualTo("/home/paul");
+    assertThat(context.concat("/", "paul")).isEqualTo("/paul");
+    assertThat(context.concat("", "paul")).isEqualTo("paul");
   }
 
   @Test
-  void resolve_using_go_path() throws IOException {
-    Path tmpGoDir = Files.createTempDirectory("tmp_go_path");
-    tmpGoDir.toFile().deleteOnExit();
-    Path srcDir = tmpGoDir.resolve("src");
-    Files.createDirectory(srcDir);
-    Files.createFile(srcDir.resolve("file.go"));
+  void concat_windows() {
+    GoPathContext context = new GoPathContext('\\', ";", "C:\\Users\\paul\\go");
+    assertThat(context.concat("C:\\Users", "paul")).isEqualTo("C:\\Users\\paul");
+    assertThat(context.concat("C:\\Users\\", "paul")).isEqualTo("C:\\Users\\paul");
+    assertThat(context.concat("C:\\", "paul")).isEqualTo("C:\\paul");
+    assertThat(context.concat("", "paul")).isEqualTo("paul");
+  }
 
-    String validGoPath = tmpGoDir.toAbsolutePath().toString();
-    String invalidPath1 = Paths.get("directory", "not", "found", "one").toString();
-    String invalidPath2 = Paths.get("directory", "not", "found", "two").toString();
+  @Test
+  void multiple_go_path_entries_linux() {
+    GoPathContext context = new GoPathContext('/', ":", ":/home/paul/go:::/home/luc/go::");
+    assertThat(context.goSrcPathList).containsExactly("/home/paul/go/src", "/home/luc/go/src");
+  }
 
-    String goPath = validGoPath;
+  @Test
+  void multiple_go_path_entries_windows() {
+    GoPathContext context = new GoPathContext('\\', ";", ";;C:\\Users\\paul\\go;C:\\Users\\luc\\go");
+    assertThat(context.goSrcPathList).containsExactly("C:\\Users\\paul\\go\\src", "C:\\Users\\luc\\go\\src");
+  }
+
+  @Test
+  void resolve_existing_file() throws IOException {
+    String goPath = tmpDirWithFile[0];
     GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
-    String expected = validGoPath + File.separatorChar + "src" + File.separatorChar + "file.go";
-    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
+    assertThat(context.resolve("file.go")).isEqualTo(existingFileAbsolutePath[0]);
     assertThat(context.resolvedPaths.keySet()).containsExactly("file.go");
-    assertThat(context.resolvedPaths.values()).containsExactly(expected);
-
-    goPath = invalidPath1 + File.pathSeparator + invalidPath2 + File.pathSeparator + validGoPath;
-    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
-    expected = validGoPath + File.separatorChar + "src" + File.separatorChar + "file.go";
-    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
-
-    goPath = validGoPath + File.pathSeparator + invalidPath1;
-    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
-    expected = validGoPath + File.separatorChar + "src" + File.separatorChar + "file.go";
-    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
-
-    goPath = invalidPath1 + File.pathSeparator + invalidPath2;
-    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
-    expected = invalidPath1 + File.separatorChar + "src" + File.separatorChar + "file.go";
-    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
-
-    goPath = File.pathSeparator + File.pathSeparator;
-    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
-    expected = "file.go";
-    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
-
-    goPath = null;
-    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
-    expected = "file.go";
-    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
+    assertThat(context.resolvedPaths.values()).containsExactly(existingFileAbsolutePath[0]);
   }
 
   @Test
-  void resolve_absolute_path() throws IOException {
-    GoPathContext linuxContext = new GoPathContext('/', ":", "/home/paul/go");
-    assertThat(linuxContext.resolveUsingGoPath("_/my-app/my-app.go")).isEqualTo("/my-app/my-app.go");
-    assertThat(linuxContext.resolveUsingGoPath("my-app/my-app.go")).isEqualTo("/home/paul/go/src/my-app/my-app.go");
+  void resolve_existing_file_multiple_go_path_entries() throws IOException {
+    String goPath = tmpDirWithFile[0] + File.pathSeparator + tmpDirWithFile[1];
+    GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    assertThat(context.resolve("file.go")).isEqualTo(existingFileAbsolutePath[0]);
+    assertThat(context.resolvedPaths.keySet()).containsExactly("file.go");
+    assertThat(context.resolvedPaths.values()).containsExactly(existingFileAbsolutePath[0]);
+  }
 
-    GoPathContext windowsContext = new GoPathContext('\\', ";", "C:\\Users\\paul\\go");
-    assertThat(windowsContext.resolveUsingGoPath("_\\C_\\my-app\\my-app.go")).isEqualTo("C:\\my-app\\my-app.go");
-    assertThat(windowsContext.resolveUsingGoPath("my-app\\my-app.go")).isEqualTo("C:\\Users\\paul\\go\\src\\my-app\\my-app.go");
+  @Test
+  void resolve_existing_file_in_the_first_go_path_entry() throws IOException {
+    String goPath = tmpDirWithFile[0] + File.pathSeparator + tmpDirWithoutFile + File.pathSeparator + invalidTmpDir;
+    GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    assertThat(context.resolve("file.go")).isEqualTo(existingFileAbsolutePath[0]);
+  }
+
+  @Test
+  void resolve_existing_file_in_the_last_go_path_entry() throws IOException {
+    String goPath = invalidTmpDir + File.pathSeparator + tmpDirWithoutFile + File.pathSeparator + tmpDirWithFile[0];
+    GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    assertThat(context.resolve("file.go")).isEqualTo(existingFileAbsolutePath[0]);
+  }
+
+  @Test
+  void resolve_none_existing_file_with_multiple_go_path_entries() throws IOException {
+    String goPath = tmpDirWithoutFile + File.pathSeparator + invalidTmpDir;
+    GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    String expected = tmpDirWithoutFile + File.separatorChar + "src" + File.separatorChar + "file.go";
+    assertThat(context.resolve("file.go")).isEqualTo(expected);
+  }
+
+  @Test
+  void resolve_none_existing_file_with_empty_go_path() throws IOException {
+    String goPath = File.pathSeparator + File.pathSeparator;
+    GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    assertThat(context.resolve("file.go")).isEqualTo("file.go");
+  }
+
+  @Test
+  void resolve_none_existing_file_with_null_go_path() throws IOException {
+    String goPath = null;
+    GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    assertThat(context.resolve("file.go")).isEqualTo("file.go");
+  }
+
+  @Test
+  void resolve_absolute_path_linux() throws IOException {
+    GoPathContext context = new GoPathContext('/', ":", "/home/paul/go");
+    assertThat(context.resolve("_/my-app/my-app.go")).isEqualTo("/my-app/my-app.go");
+  }
+
+  @Test
+  void resolve_absolute_path_windows() throws IOException {
+    GoPathContext context = new GoPathContext('\\', ";", "C:\\Users\\paul\\go");
+    assertThat(context.resolve("_\\C_\\my-app\\my-app.go")).isEqualTo("C:\\my-app\\my-app.go");
   }
 
 }

--- a/sonar-go-plugin/src/test/java/org/sonar/go/plugin/GoPathContextTest.java
+++ b/sonar-go-plugin/src/test/java/org/sonar/go/plugin/GoPathContextTest.java
@@ -1,0 +1,114 @@
+/*
+ * SonarQube Go Plugin
+ * Copyright (C) 2018-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.go.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GoPathContextTest {
+
+  @Test
+  void concat() {
+    GoPathContext linuxContext = new GoPathContext('/', ":", "/home/paul/go");
+    GoPathContext windowsContext = new GoPathContext('\\', ";", "C:\\Users\\paul\\go");
+
+    assertThat(linuxContext.concat("/home", "paul")).isEqualTo("/home/paul");
+    assertThat(linuxContext.concat("/home/", "paul")).isEqualTo("/home/paul");
+    assertThat(linuxContext.concat("/", "paul")).isEqualTo("/paul");
+    assertThat(linuxContext.concat("", "paul")).isEqualTo("paul");
+
+    assertThat(windowsContext.concat("C:\\Users", "paul")).isEqualTo("C:\\Users\\paul");
+    assertThat(windowsContext.concat("C:\\Users\\", "paul")).isEqualTo("C:\\Users\\paul");
+    assertThat(windowsContext.concat("C:\\", "paul")).isEqualTo("C:\\paul");
+    assertThat(windowsContext.concat("", "paul")).isEqualTo("paul");
+  }
+
+  @Test
+  void source_directories() {
+    GoPathContext linuxContext = new GoPathContext('/', ":", "/home/paul/go:/home/luc/go");
+    assertThat(linuxContext.goSrcPathList).containsExactly("/home/paul/go/src", "/home/luc/go/src");
+
+    GoPathContext windowsContext = new GoPathContext('\\', ";", "C:\\Users\\paul\\go;C:\\Users\\luc\\go");
+    assertThat(windowsContext.goSrcPathList).containsExactly("C:\\Users\\paul\\go\\src", "C:\\Users\\luc\\go\\src");
+  }
+
+  @Test
+  void resolve_using_go_path() throws IOException {
+    Path tmpGoDir = Files.createTempDirectory("tmp_go_path");
+    tmpGoDir.toFile().deleteOnExit();
+    Path srcDir = tmpGoDir.resolve("src");
+    Files.createDirectory(srcDir);
+    Files.createFile(srcDir.resolve("file.go"));
+
+    String validGoPath = tmpGoDir.toAbsolutePath().toString();
+    String invalidPath1 = Paths.get("directory", "not", "found", "one").toString();
+    String invalidPath2 = Paths.get("directory", "not", "found", "two").toString();
+
+    String goPath = validGoPath;
+    GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    String expected = validGoPath + File.separatorChar + "src" + File.separatorChar + "file.go";
+    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
+    assertThat(context.resolvedPaths.keySet()).containsExactly("file.go");
+    assertThat(context.resolvedPaths.values()).containsExactly(expected);
+
+    goPath = invalidPath1 + File.pathSeparator + invalidPath2 + File.pathSeparator + validGoPath;
+    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    expected = validGoPath + File.separatorChar + "src" + File.separatorChar + "file.go";
+    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
+
+    goPath = validGoPath + File.pathSeparator + invalidPath1;
+    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    expected = validGoPath + File.separatorChar + "src" + File.separatorChar + "file.go";
+    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
+
+    goPath = invalidPath1 + File.pathSeparator + invalidPath2;
+    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    expected = invalidPath1 + File.separatorChar + "src" + File.separatorChar + "file.go";
+    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
+
+    goPath = File.pathSeparator + File.pathSeparator;
+    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    expected = "file.go";
+    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
+
+    goPath = null;
+    context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    expected = "file.go";
+    assertThat(context.resolveUsingGoPath("file.go")).isEqualTo(expected);
+  }
+
+  @Test
+  void resolve_absolute_path() throws IOException {
+    GoPathContext linuxContext = new GoPathContext('/', ":", "/home/paul/go");
+    assertThat(linuxContext.resolveUsingGoPath("_/my-app/my-app.go")).isEqualTo("/my-app/my-app.go");
+    assertThat(linuxContext.resolveUsingGoPath("my-app/my-app.go")).isEqualTo("/home/paul/go/src/my-app/my-app.go");
+
+    GoPathContext windowsContext = new GoPathContext('\\', ";", "C:\\Users\\paul\\go");
+    assertThat(windowsContext.resolveUsingGoPath("_\\C_\\my-app\\my-app.go")).isEqualTo("C:\\my-app\\my-app.go");
+    assertThat(windowsContext.resolveUsingGoPath("my-app\\my-app.go")).isEqualTo("C:\\Users\\paul\\go\\src\\my-app\\my-app.go");
+  }
+
+}

--- a/sonar-go-plugin/src/test/java/org/sonar/go/plugin/GoPathContextTest.java
+++ b/sonar-go-plugin/src/test/java/org/sonar/go/plugin/GoPathContextTest.java
@@ -47,6 +47,8 @@ class GoPathContextTest {
       Files.createDirectory(srcDir);
       Path existingFile = srcDir.resolve("file.go");
       Files.createFile(existingFile);
+      Path packageDir = dirWithFile.resolve("my-package");
+      Files.createDirectory(packageDir);
       tmpDirWithFile[i] = dirWithFile.toAbsolutePath().toString();
       existingFileAbsolutePath[i] = existingFile.toAbsolutePath().toString();
     }
@@ -96,6 +98,14 @@ class GoPathContextTest {
     assertThat(context.resolve("file.go")).isEqualTo(existingFileAbsolutePath[0]);
     assertThat(context.resolvedPaths.keySet()).containsExactly("file.go");
     assertThat(context.resolvedPaths.values()).containsExactly(existingFileAbsolutePath[0]);
+  }
+
+  @Test
+  void resolve_existing_directory() throws IOException {
+    String goPath = tmpDirWithFile[0];
+    GoPathContext context = new GoPathContext(File.separatorChar, File.pathSeparator, goPath);
+    String expected = tmpDirWithFile[0] + File.separatorChar + "src" + File.separatorChar + "my-package";
+    assertThat(context.resolve("my-package")).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
Extract GOPATH path resolution mechanism so test report sensor could use it