### PR TITLE
Rule S1763 FN: fix multiple jumps scenario

### DIFF
--- a/common-rule-engine/src/main/java/org/sonar/commonruleengine/checks/UnreachableCodeCheck.java
+++ b/common-rule-engine/src/main/java/org/sonar/commonruleengine/checks/UnreachableCodeCheck.java
@@ -37,9 +37,12 @@ public class UnreachableCodeCheck extends Check {
     ListIterator<UastNode> stmtIterator = statements.listIterator();
     while (stmtIterator.hasNext()) {
       if (stmtIterator.next().is(UastNode.Kind.UNCONDITIONAL_JUMP)) {
-        break;
+        checkDeadCode(stmtIterator);
       }
     }
+  }
+
+  private void checkDeadCode(ListIterator<UastNode> stmtIterator) {
     if (stmtIterator.hasNext()) {
       UastNode jump = stmtIterator.previous();
       stmtIterator.next();

--- a/common-rule-engine/src/test/files/checks/UnreachableCodeCheck/UnreachableCodeCheck.go
+++ b/common-rule-engine/src/test/files/checks/UnreachableCodeCheck/UnreachableCodeCheck.go
@@ -36,3 +36,11 @@ func switchcase(x int) {
 		fmt.Print("Hello")
 	}
 }
+
+func multipleJumps() {
+	goto lable
+lable:
+	fmt.Println("happen")
+	return // Noncompliant {{Refactor this piece of code to not have any dead code after this return.}}
+	fmt.Println("never happen")
+}


### PR DESCRIPTION
origin code checks for LABEL statement only once, so it'll failed in a method with multiple jumps.