### PR TITLE
Add golangci-lint format accepted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ build/
 
 # --- Maven and Orchestrator
 target/
+
+# --- jenv
+.java-version

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoPlugin.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/GoPlugin.java
@@ -26,6 +26,7 @@ import org.sonar.api.utils.Version;
 import org.sonar.go.plugin.externalreport.GoLintReportSensor;
 import org.sonar.go.plugin.externalreport.GoMetaLinterReportSensor;
 import org.sonar.go.plugin.externalreport.GoVetReportSensor;
+import org.sonar.go.plugin.externalreport.GolangCILinterReportSensor;
 
 public class GoPlugin implements Plugin {
 
@@ -53,6 +54,7 @@ public class GoPlugin implements Plugin {
       GoVetReportSensor.class,
       GoLintReportSensor.class,
       GoMetaLinterReportSensor.class,
+      GolangCILinterReportSensor.class,
 
       PropertyDefinition.builder(GoLanguage.FILE_SUFFIXES_KEY)
         .index(10)
@@ -130,7 +132,19 @@ public class GoPlugin implements Plugin {
           .onQualifiers(Qualifiers.PROJECT)
           .defaultValue("")
           .multiValues(true)
-          .build());
+          .build(),
+
+        PropertyDefinition.builder(GolangCILinterReportSensor.PROPERTY_KEY)
+           .index(33)
+           .name("golangci-lint Report files")
+           .description("Paths (absolute or relative) to the files with golangci-lint issues")
+           .category(GO_CATEGORY)
+           .subCategory(EXTERNAL_LINTER_SUBCATEGORY)
+           .onQualifiers(Qualifiers.PROJECT)
+           .defaultValue("")
+           .multiValues(true)
+           .build()
+      );
     }
   }
 }

--- a/sonar-go-plugin/src/main/java/org/sonar/go/plugin/externalreport/GolangCILinterReportSensor.java
+++ b/sonar-go-plugin/src/main/java/org/sonar/go/plugin/externalreport/GolangCILinterReportSensor.java
@@ -1,0 +1,57 @@
+package org.sonar.go.plugin.externalreport;
+
+import org.sonar.api.rules.RuleType;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import javax.annotation.Nullable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GolangCILinterReportSensor extends AbstractReportSensor {
+    private static final Logger LOG = Loggers.get(GolangCILinterReportSensor.class);
+
+    public static final String PROPERTY_KEY = "sonar.go.golangci-lint.reportPaths";
+
+    private static final Pattern GOLANGCI_LINT_REGEX = Pattern.compile("(?<file>[^:]+):(?<line>\\d+):(?<col>\\d+)\\s*(?<linter>\\S+)\\s*(?<message>.*)");
+
+    @Override
+    String linterName() {
+        return "GolangCILinter";
+    }
+
+    @Override
+    String reportsPropertyName() {
+        return PROPERTY_KEY;
+    }
+
+    @Nullable
+    @Override
+    ExternalIssue parse(String line) {
+        Matcher matcher = GOLANGCI_LINT_REGEX.matcher(line);
+        if (matcher.matches()) {
+            String linter = mapLinterName(matcher.group("linter").trim());
+            String filename = matcher.group("file").trim();
+            int lineNumber = Integer.parseInt(matcher.group("line").trim());
+            String message = matcher.group("message").trim();
+
+            // Golang CI doesn't currently output the severity or type. so for now
+            // we generically adding a default of CODE_SMELL for now
+            RuleType type =  RuleType.CODE_SMELL;
+            String ruleKey = null;
+
+            return new ExternalIssue(linter, type, ruleKey, filename, lineNumber, message);
+        } else {
+            LOG.debug(logPrefix() + "Unexpected line: " + line);
+        }
+        return null;
+    }
+
+    private static String mapLinterName(String linter) {
+        if ("govet".equals(linter)) {
+            return GoVetReportSensor.LINTER_ID;
+        }
+        return linter;
+    }
+
+}

--- a/sonar-go-plugin/src/test/java/org/sonar/go/plugin/externalreport/GolangCILinterSensorTest.java
+++ b/sonar-go-plugin/src/test/java/org/sonar/go/plugin/externalreport/GolangCILinterSensorTest.java
@@ -1,0 +1,91 @@
+package org.sonar.go.plugin.externalreport;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.batch.sensor.issue.ExternalIssue;
+import org.sonar.api.rules.RuleType;
+import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.go.plugin.JUnit5LogTester;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.go.plugin.externalreport.ExternalLinterSensorHelper.REPORT_BASE_PATH;
+
+public class GolangCILinterSensorTest {
+    @RegisterExtension
+    static JUnit5LogTester logTester = new JUnit5LogTester();
+
+    @BeforeEach
+    void setUp() {
+        logTester.clear();
+    }
+
+    @Test
+    public void test_descriptor() {
+        DefaultSensorDescriptor sensorDescriptor = new DefaultSensorDescriptor();
+        new GolangCILinterReportSensor().describe(sensorDescriptor);
+        assertThat(sensorDescriptor.name()).isEqualTo("Import of GolangCILinter issues");
+        assertThat(sensorDescriptor.languages()).containsOnly("go");
+    }
+
+    @Test
+    void issues_with_sonarqube_72() throws IOException {
+        SensorContextTester context = ExternalLinterSensorHelper.createContext(7, 2);
+        context.settings().setProperty("sonar.go.golangci-lint.reportPaths", REPORT_BASE_PATH.resolve("golangci-lint-report.txt").toString());
+        List<ExternalIssue> externalIssues = ExternalLinterSensorHelper.executeSensor(new GolangCILinterReportSensor(), context);
+        assertThat(externalIssues).hasSize(5);
+
+        org.sonar.api.batch.sensor.issue.ExternalIssue first = externalIssues.get(0);
+        assertThat(first.type()).isEqualTo(RuleType.CODE_SMELL);
+        assertThat(first.ruleKey().repository()).isEqualTo("errcheck");
+        assertThat(first.primaryLocation().message()).isEqualTo("Error return value of `(*encoding/json.Encoder).Encode` is not checked");
+        assertThat(first.primaryLocation().textRange().start().line()).isEqualTo(5);
+
+        org.sonar.api.batch.sensor.issue.ExternalIssue second = externalIssues.get(1);
+        assertThat(second.type()).isEqualTo(RuleType.CODE_SMELL);
+        assertThat(second.ruleKey().repository()).isEqualTo("errcheck");
+        assertThat(second.primaryLocation().message()).isEqualTo("Error return value of `(*encoding/json.Encoder).Encode` is not checked");
+        assertThat(second.primaryLocation().textRange().start().line()).isEqualTo(3);
+
+        org.sonar.api.batch.sensor.issue.ExternalIssue third = externalIssues.get(2);
+        assertThat(third.type()).isEqualTo(RuleType.CODE_SMELL);
+        assertThat(third.ruleKey().repository()).isEqualTo("govet");
+        assertThat(third.ruleKey().rule()).isEqualTo("issue");
+        assertThat(third.primaryLocation().message()).isEqualTo("Errorf format %v reads arg #1, but call has 0 args");
+        assertThat(third.primaryLocation().textRange().start().line()).isEqualTo(2);
+
+
+
+        org.sonar.api.batch.sensor.issue.ExternalIssue forth = externalIssues.get(3);
+        assertThat(forth.type()).isEqualTo(RuleType.CODE_SMELL);
+        assertThat(forth.ruleKey().repository()).isEqualTo("errcheck");
+        assertThat(forth.primaryLocation().message()).isEqualTo("Error return value of `(*encoding/json.Encoder).Encode` is not checked");
+        assertThat(forth.primaryLocation().textRange().start().line()).isEqualTo(1);
+
+        org.sonar.api.batch.sensor.issue.ExternalIssue fifth = externalIssues.get(4);
+        assertThat(fifth.type()).isEqualTo(RuleType.CODE_SMELL);
+        assertThat(fifth.ruleKey().repository()).isEqualTo("staticcheck");
+        assertThat(fifth.primaryLocation().message()).isEqualTo("session.New is deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.");
+        assertThat(fifth.primaryLocation().textRange().start().line()).isEqualTo(2);
+
+        assertThat(logTester.logs(LoggerLevel.ERROR)).isEmpty();
+    }
+
+    @Test
+    void no_issues_with_invalid_report_line() throws IOException {
+        SensorContextTester context = ExternalLinterSensorHelper.createContext(7, 2);
+        context.settings().setProperty("sonar.go.golangci-lint.reportPaths", REPORT_BASE_PATH.resolve("golangci-lint-with-error.txt").toString());
+        List<ExternalIssue> externalIssues = ExternalLinterSensorHelper.executeSensor(new GolangCILinterReportSensor(), context);
+        assertThat(externalIssues).hasSize(1);
+        assertThat(logTester.logs(LoggerLevel.ERROR)).hasSize(0);
+        assertThat(logTester.logs(LoggerLevel.DEBUG)).hasSize(1);
+        assertThat(logTester.logs(LoggerLevel.DEBUG).get(0)).startsWith("GolangCILinterReportSensor: Unexpected line: thisisaninvalidline");
+    }
+
+
+}

--- a/sonar-go-plugin/src/test/resources/externalreport/golangci-lint-report.txt
+++ b/sonar-go-plugin/src/test/resources/externalreport/golangci-lint-report.txt
@@ -1,0 +1,5 @@
+main.go:5:29  errcheck     Error return value of `(*encoding/json.Encoder).Encode` is not checked
+main.go:3:29  errcheck     Error return value of `(*encoding/json.Encoder).Encode` is not checked
+main.go:2:9   govet        Errorf format %v reads arg #1, but call has 0 args
+main.go:1:28  errcheck     Error return value of `(*encoding/json.Encoder).Encode` is not checked
+main.go:2:17  staticcheck  session.New is deprecated: Use NewSession functions to create sessions instead. NewSession has the same functionality as New except an error can be returned when the func is called instead of waiting to receive an error until a request is made.

--- a/sonar-go-plugin/src/test/resources/externalreport/golangci-lint-with-error.txt
+++ b/sonar-go-plugin/src/test/resources/externalreport/golangci-lint-with-error.txt
@@ -1,0 +1,2 @@
+thisisaninvalidline
+main.go:5:29  errcheck     Error return value of `(*encoding/json.Encoder).Encode` is not checked


### PR DESCRIPTION
Resolves #355.

Adds native support for golangci-lint reports.

To use the new format, one must run the following golangci-lint command:

```
golangci-lint run --out-format tab > golangci-lint-output.txt
```

cc\ @pwmcintyre